### PR TITLE
pipeline.yaml: rename build step to "test"

### DIFF
--- a/.banzaicloud/pipeline.yaml
+++ b/.banzaicloud/pipeline.yaml
@@ -7,7 +7,7 @@ pipeline:
     image: banzaicloud/ci-pipeline-client:0.10
     action: EnsureCluster
 
-  build:
+  test:
     image: golang:1.11
     commands: make vendor check
     environment:


### PR DESCRIPTION
The "build" step runs builds the code, and runs the lint/tests, but the rest of the flow does not use the built image. "test" is more descriptive name for this step.