### PR TITLE
[Makefile] Support reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OPENAPI_DESCRIPTOR_DIR = api/openapi
 BUILD_DIR ?= build
 VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD)
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null)
-BUILD_DATE ?= $(shell date +%FT%T%z)
+BUILD_DATE ?= $(shell date --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%FT%T%z)
 LDFLAGS += -X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH} -X main.buildDate=${BUILD_DATE}
 export CGO_ENABLED ?= 0
 ifeq (${VERBOSE}, 1)


### PR DESCRIPTION
Embedding build times is generally poor form as it introduces
undeterministic builds. To ensure the binaries are reproducible, we
should be looking for `SOURCE_DATE_EPOCH` in the build environment as
specified by the reproducible builds project.

https://reproducible-builds.org/docs/source-date-epoch/