### PR TITLE
Windows support

### DIFF
--- a/internal/platform/reloader/interface.go
+++ b/internal/platform/reloader/interface.go
@@ -1,0 +1,13 @@
+package reloader
+
+import (
+	"context"
+	"net"
+
+	"github.com/oklog/run"
+)
+
+type Reloader interface {
+	Listen(network, address string) (net.Listener, error)
+	SetupGracefulRestart(context.Context, run.Group)
+}

--- a/internal/platform/reloader/reloader.go
+++ b/internal/platform/reloader/reloader.go
@@ -1,0 +1,40 @@
+// +build !windows
+
+package reloader
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/cloudflare/tableflip"
+	"github.com/oklog/run"
+	appkitrun "github.com/sagikazarmark/appkit/run"
+	"logur.dev/logur"
+)
+
+type TableflipReloader struct {
+	*tableflip.Upgrader
+}
+
+func Create(logger logur.LoggerFacade) *Reloader {
+	upg, _ := tableflip.New(tableflip.Options{})
+
+	// Do an upgrade on SIGHUP
+	go func() {
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGHUP)
+		for range ch {
+			logger.Info("graceful reloading")
+
+			_ = upg.Upgrade()
+		}
+	}()
+
+	return &TableflipReloader{upg}
+}
+
+func (t *TableflipReloader) SetupGracefulRestart(context context.Context, group run.Group) {
+	group.Add(appkitrun.GracefulRestart(context, t))
+}

--- a/internal/platform/reloader/reloader_windows.go
+++ b/internal/platform/reloader/reloader_windows.go
@@ -1,0 +1,26 @@
+package reloader
+
+import (
+	"context"
+	"net"
+
+	"github.com/oklog/run"
+	"logur.dev/logur"
+)
+
+type UnsupportedReloader struct {
+}
+
+func Create(logger logur.LoggerFacade) Reloader {
+	logger.Warn("graceful reload is not supported on this platform")
+
+	return &UnsupportedReloader{}
+}
+
+func (t *UnsupportedReloader) Listen(network, address string) (net.Listener, error) {
+	return net.Listen(network, address)
+}
+
+func (t *UnsupportedReloader) SetupGracefulRestart(context context.Context, group run.Group) {
+	// no-op since it isn't supported
+}


### PR DESCRIPTION
This PR allows applications to run on Windows.

The application will not support graceful restart, since TableFlip doesn't have Windows support, but it is still adequate for users who use Windows machines for development and Linux for production.

It extracts the tableflip code into `internal/platform/reloader` with conditional compilation depending on which platform is being used.

I have not finished testing it yet, but I wanted to get it out here to see if you want any changes to it.